### PR TITLE
remove sqlite dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ goose will expand environment variables in the `open` element. For an example, s
 ## Other Drivers
 goose knows about some common SQL drivers, but it can still be used to run Go-based migrations with any driver supported by `database/sql`. An import path and known dialect are required.
 
-Currently, available dialects are: "postgres", "mysql", or "sqlite3"
+Currently, available dialects are: "postgres", or "mysql"
 
 To run Go-based migrations with another driver, specify its import path and dialect, as shown below.
 

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -104,10 +104,6 @@ func newDBDriver(name, open string) DBDriver {
 	case "mysql":
 		d.Import = "github.com/go-sql-driver/mysql"
 		d.Dialect = &MySqlDialect{}
-
-	case "sqlite3":
-		d.Import = "github.com/mattn/go-sqlite3"
-		d.Dialect = &Sqlite3Dialect{}
 	}
 
 	return d

--- a/lib/goose/dbconf_test.go
+++ b/lib/goose/dbconf_test.go
@@ -1,10 +1,6 @@
 package goose
 
-import (
-	"os"
-	"reflect"
-	"testing"
-)
+import "testing"
 
 func TestBasics(t *testing.T) {
 
@@ -34,37 +30,5 @@ func TestImportOverride(t *testing.T) {
 	want := "github.com/custom/driver"
 	if got != want {
 		t.Errorf("bad custom import. got %v want %v", got, want)
-	}
-}
-
-func TestDriverSetFromEnvironmentVariable(t *testing.T) {
-
-	databaseUrlEnvVariableKey := "DB_DRIVER"
-	databaseUrlEnvVariableVal := "sqlite3"
-	databaseOpenStringKey := "DATABASE_URL"
-	databaseOpenStringVal := "db.db"
-
-	os.Setenv(databaseUrlEnvVariableKey, databaseUrlEnvVariableVal)
-	os.Setenv(databaseOpenStringKey, databaseOpenStringVal)
-
-	dbconf, err := NewDBConf("../../db-sample", "environment_variable_config", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	got := reflect.TypeOf(dbconf.Driver.Dialect)
-	want := reflect.TypeOf(&Sqlite3Dialect{})
-
-	if got != want {
-		t.Errorf("Not able to read the driver type from environment variable."+
-			"got %v want %v", got, want)
-	}
-
-	gotOpenString := dbconf.Driver.OpenStr
-	wantOpenString := databaseOpenStringVal
-
-	if gotOpenString != wantOpenString {
-		t.Errorf("Not able to read the open string from the environment."+
-			"got %v want %v", gotOpenString, wantOpenString)
 	}
 }

--- a/lib/goose/dialect.go
+++ b/lib/goose/dialect.go
@@ -2,7 +2,6 @@ package goose
 
 import (
 	"database/sql"
-	"github.com/mattn/go-sqlite3"
 )
 
 // SqlDialect abstracts the details of specific SQL dialects
@@ -20,8 +19,6 @@ func dialectByName(d string) SqlDialect {
 		return &PostgresDialect{}
 	case "mysql":
 		return &MySqlDialect{}
-	case "sqlite3":
-		return &Sqlite3Dialect{}
 	}
 
 	return nil
@@ -90,34 +87,5 @@ func (m MySqlDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 		return nil, ErrTableDoesNotExist
 	}
 
-	return rows, err
-}
-
-////////////////////////////
-// sqlite3
-////////////////////////////
-
-type Sqlite3Dialect struct{}
-
-func (m Sqlite3Dialect) createVersionTableSql() string {
-	return `CREATE TABLE goose_db_version (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                version_id INTEGER NOT NULL,
-                is_applied INTEGER NOT NULL,
-                tstamp TIMESTAMP DEFAULT (datetime('now'))
-            );`
-}
-
-func (m Sqlite3Dialect) insertVersionSql() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
-}
-
-func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
-
-	switch err.(type) {
-	case sqlite3.Error:
-		return nil, ErrTableDoesNotExist
-	}
 	return rows, err
 }

--- a/lib/goose/migrate.go
+++ b/lib/goose/migrate.go
@@ -15,7 +15,6 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/ziutek/mymysql/godrv"
 )
 

--- a/lib/goose/migration_go.go
+++ b/lib/goose/migration_go.go
@@ -24,7 +24,6 @@ type templateData struct {
 func init() {
 	gob.Register(PostgresDialect{})
 	gob.Register(MySqlDialect{})
-	gob.Register(Sqlite3Dialect{})
 }
 
 //


### PR DESCRIPTION
This is to make the transition to bazel easier. bazel's rule_go doesn't
yet handle cgo build tags and go-sqlite3 depends on them on Linux.

As a side effect, we do get faster builds. That's nice.
